### PR TITLE
Regenerate with corrected Cursor field

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dyspatch API
 - API version: 2019.10
-  - Build date: 2019-12-04T10:26:06.860-08:00
+  - Build date: 2019-12-04T17:48:43.587-08:00
 
 # Introduction
 
@@ -55,7 +55,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>io.dyspatch</groupId>
   <artifactId>dyspatch-java</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2</version>
 </dependency>
 ```
 
@@ -64,7 +64,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "io.dyspatch:dyspatch-java:3.0.1"
+compile "io.dyspatch:dyspatch-java:3.0.2"
 ```
 
 ### Others
@@ -77,7 +77,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/dyspatch-java-3.0.1.jar`
+* `target/dyspatch-java-3.0.2.jar`
 * `target/lib/*.jar`
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dyspatch-java
+# Dyspatch Java API client
 
 Dyspatch API
 - API version: 2019.10

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group = 'io.dyspatch'
-version = '3.0.1'
+version = '3.0.2'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "io.dyspatch",
     name := "dyspatch-java",
-    version := "3.0.1",
+    version := "3.0.2",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/docs/DraftsRead.md
+++ b/docs/DraftsRead.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**cursor** | **Object** | Information about paginated results |  [optional]
+**cursor** | [**Cursor**](Cursor.md) |  |  [optional]
 **data** | [**List&lt;DraftMetaRead&gt;**](DraftMetaRead.md) | A list of draft metadata objects |  [optional]
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>dyspatch-java</artifactId>
     <packaging>jar</packaging>
     <name>dyspatch-java</name>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <url>https://github.com/getdyspatch/dyspatch-java/</url>
     <description>dyspatch-java</description>
     <scm>

--- a/src/main/java/io/dyspatch/client/ApiClient.java
+++ b/src/main/java/io/dyspatch/client/ApiClient.java
@@ -85,7 +85,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("Swagger-Codegen/3.0.1/java");
+        setUserAgent("Swagger-Codegen/3.0.2/java");
 
         // Setup authentications (key: authentication name, value: authentication).
         authentications = new HashMap<String, Authentication>();

--- a/src/main/java/io/dyspatch/client/ApiException.java
+++ b/src/main/java/io/dyspatch/client/ApiException.java
@@ -16,7 +16,7 @@ package io.dyspatch.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/io/dyspatch/client/Configuration.java
+++ b/src/main/java/io/dyspatch/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package io.dyspatch.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/io/dyspatch/client/Pair.java
+++ b/src/main/java/io/dyspatch/client/Pair.java
@@ -13,7 +13,7 @@
 
 package io.dyspatch.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/io/dyspatch/client/StringUtil.java
+++ b/src/main/java/io/dyspatch/client/StringUtil.java
@@ -13,7 +13,7 @@
 
 package io.dyspatch.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/io/dyspatch/client/auth/ApiKeyAuth.java
+++ b/src/main/java/io/dyspatch/client/auth/ApiKeyAuth.java
@@ -18,7 +18,7 @@ import io.dyspatch.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/io/dyspatch/client/auth/OAuth.java
+++ b/src/main/java/io/dyspatch/client/auth/OAuth.java
@@ -18,7 +18,7 @@ import io.dyspatch.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/src/main/java/io/dyspatch/client/model/APIError.java
+++ b/src/main/java/io/dyspatch/client/model/APIError.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * APIError
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class APIError {
   /**
    * Error code:   * server_error - Internal server error.   * invalid_parameter - Validation error, parameter will contain invalid field and message will contain the reason.   * invalid_body - Body could not be parsed, message will contain the reason.   * invalid_request - Validation error, the protocol used to make the request was not https.   * unauthorized - Credentials were found but permissions were not sufficient.   * unauthenticated - Credentials were not found or were not valid.   * not_found - The requested resource was not found.   * rate_limited - The request was refused because a rate limit was exceeded. There is an account wide rate limit of 3600 requests per-minute, although that is subject to change. The current remaining rate limit can be viewed by checking the X-Ratelimit-Remaining header. 

--- a/src/main/java/io/dyspatch/client/model/Body.java
+++ b/src/main/java/io/dyspatch/client/model/Body.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * Body
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class Body {
   @SerializedName("name")
   private String name = null;

--- a/src/main/java/io/dyspatch/client/model/CompiledRead.java
+++ b/src/main/java/io/dyspatch/client/model/CompiledRead.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * CompiledRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class CompiledRead {
   @SerializedName("sender")
   private String sender = null;

--- a/src/main/java/io/dyspatch/client/model/Cursor.java
+++ b/src/main/java/io/dyspatch/client/model/Cursor.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * Information about paginated results
  */
 @ApiModel(description = "Information about paginated results")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class Cursor {
   @SerializedName("next")
   private String next = null;

--- a/src/main/java/io/dyspatch/client/model/DraftMetaRead.java
+++ b/src/main/java/io/dyspatch/client/model/DraftMetaRead.java
@@ -28,7 +28,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * DraftMetaRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class DraftMetaRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/DraftRead.java
+++ b/src/main/java/io/dyspatch/client/model/DraftRead.java
@@ -32,7 +32,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * DraftRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class DraftRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/DraftsRead.java
+++ b/src/main/java/io/dyspatch/client/model/DraftsRead.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import io.dyspatch.client.model.Cursor;
 import io.dyspatch.client.model.DraftMetaRead;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -30,29 +31,29 @@ import java.util.List;
 /**
  * DraftsRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class DraftsRead {
   @SerializedName("cursor")
-  private Object cursor = null;
+  private Cursor cursor = null;
 
   @SerializedName("data")
   private List<DraftMetaRead> data = null;
 
-  public DraftsRead cursor(Object cursor) {
+  public DraftsRead cursor(Cursor cursor) {
     this.cursor = cursor;
     return this;
   }
 
    /**
-   * Information about paginated results
+   * Get cursor
    * @return cursor
   **/
-  @ApiModelProperty(value = "Information about paginated results")
-  public Object getCursor() {
+  @ApiModelProperty(value = "")
+  public Cursor getCursor() {
     return cursor;
   }
 
-  public void setCursor(Object cursor) {
+  public void setCursor(Cursor cursor) {
     this.cursor = cursor;
   }
 

--- a/src/main/java/io/dyspatch/client/model/LocalizationKeyRead.java
+++ b/src/main/java/io/dyspatch/client/model/LocalizationKeyRead.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * LocalizationKeyRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class LocalizationKeyRead {
   @SerializedName("key")
   private String key = null;

--- a/src/main/java/io/dyspatch/client/model/LocalizationMetaRead.java
+++ b/src/main/java/io/dyspatch/client/model/LocalizationMetaRead.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * LocalizationMetaRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class LocalizationMetaRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/LocalizationRead.java
+++ b/src/main/java/io/dyspatch/client/model/LocalizationRead.java
@@ -29,7 +29,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * LocalizationRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class LocalizationRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/TemplateMetaRead.java
+++ b/src/main/java/io/dyspatch/client/model/TemplateMetaRead.java
@@ -31,7 +31,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * TemplateMetaRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class TemplateMetaRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/TemplateRead.java
+++ b/src/main/java/io/dyspatch/client/model/TemplateRead.java
@@ -32,7 +32,7 @@ import org.threeten.bp.OffsetDateTime;
 /**
  * TemplateRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class TemplateRead {
   @SerializedName("id")
   private String id = null;

--- a/src/main/java/io/dyspatch/client/model/TemplatesRead.java
+++ b/src/main/java/io/dyspatch/client/model/TemplatesRead.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * TemplatesRead
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T10:55:38.642-08:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-12-04T17:48:43.587-08:00")
 public class TemplatesRead {
   @SerializedName("cursor")
   private Cursor cursor = null;


### PR DESCRIPTION
The `getCursor()` on the `draftsRead` class will now return a Cursor instead of a generic Object. This will allow end users to page through draft results from the `/drafts` endpoint.